### PR TITLE
Adding build script for server

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "A Porta (3scale API MGMT) Patternfly React app served with a BFF layer",
   "main": "index.js",
   "scripts": {
+    "build:server": "tsc",
     "dependencies": "yarn install && cd app && yarn install",
-    "start": "npm run start:server && npm run start:app",
+    "start": "npm run build:server && npm run start:app",
     "start:app": "cd app && npm start",
     "start:server": "cd server && npm start",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Running `npm start` falls into an infinite loop
Build of server.ts is missing